### PR TITLE
Fix decompression for arbitrary-size payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+*.o
+*.a
+/lzvn

--- a/lzvn.c
+++ b/lzvn.c
@@ -216,7 +216,12 @@ int main(int argc, const char * argv[])
                             while (1)
                             {
                                 compsize = lzvn_decode(uncompressedBuffer, workSpaceSize, fileBuffer, fileLength);
-                                if(compsize > 0 && compsize < workSpaceSize)
+                                if(compsize == 0)
+                                {
+                                    printf("ERROR: Decompression errored out (truncated input?)... exiting\nAborted!\n\n");
+                                    return -1;
+                                }
+                                if(compsize < workSpaceSize)
                                 {
                                     fwrite(uncompressedBuffer, 1, compsize, fp);
                                     break;

--- a/lzvn.c
+++ b/lzvn.c
@@ -199,6 +199,11 @@ int main(int argc, const char * argv[])
                     } else {
                         size_t workSpaceSize = lzvn_encode_work_size();
 
+                        if (fileLength > workSpaceSize)
+                        {
+                            workSpaceSize = fileLength;
+                        }
+
                         printf("workSpaceSize: %ld \n", workSpaceSize);
                         uncompressedBuffer = malloc(workSpaceSize);
 
@@ -208,14 +213,23 @@ int main(int argc, const char * argv[])
 
                             return -1;
                         } else {
-                            while ((compsize = lzvn_decode(uncompressedBuffer, workSpaceSize, fileBuffer, fileLength)) > 0)
+                            while (1)
                             {
-                                fwrite(uncompressedBuffer, 1, compsize, fp);
-                                fileBuffer += workSpaceSize;
-                                byteshandled += workSpaceSize;
+                                compsize = lzvn_decode(uncompressedBuffer, workSpaceSize, fileBuffer, fileLength);
+                                if(compsize > 0 && compsize < workSpaceSize)
+                                {
+                                    fwrite(uncompressedBuffer, 1, compsize, fp);
+                                    break;
+                                }
+                                workSpaceSize *= 2;
+                                printf("workSpaceSize: %ld \n", workSpaceSize);
+                                uncompressedBuffer = realloc(uncompressedBuffer, workSpaceSize);
+                                if (uncompressedBuffer == NULL)
+                                {
+                                    printf("ERROR: Failed to allocate uncompressed buffer... exiting\nAborted!\n\n");
+                                    return -1;
+                                }
                             }
-
-                            fileBuffer -= byteshandled;
 
                             if (fileBuffer != NULL)
                             {


### PR DESCRIPTION
Decoding is currently broken for any payload that decompresses to a size bigger than `workSpaceSize`.  
The loop that calls `lzvn_decode` advances the input ptr by `workSpaceSize`, but that's not the amount of bytes actually used up - which is something the function doesn't tell you. And even if it did, there may be a loss of internal state.

So without re-architecting `lzvn_decode`, the fix is to repeatedly increase `workSpaceSize` until `lzvn_decode` no longer uses up the entire buffer. This PR does just that.